### PR TITLE
Re-authenticate when refresh token is expired

### DIFF
--- a/api_methods.go
+++ b/api_methods.go
@@ -179,7 +179,7 @@ func (e *VastResource) DeleteWithContext(ctx context.Context, searchParams, quer
 				" and thereby cannot be deleted by id", e.GetResourceType(),
 		)
 	}
-    return e.DeleteByIdWithContext(ctx, idVal, queryParams, deleteParams)
+	return e.DeleteByIdWithContext(ctx, idVal, queryParams, deleteParams)
 }
 
 // DeleteNonIdWithContext deletes a resource that does not use a numeric ID for identification.
@@ -304,19 +304,19 @@ func (e *VastResource) UpdateNonId(params Params) (Record, error) {
 // Delete deletes a resource found with searchParams using deleteParams and the bound REST context.
 // Returns success even if the resource is not found.
 func (e *VastResource) Delete(searchParams, deleteParams Params) (EmptyRecord, error) {
-    return e.DeleteWithContext(e.rest.ctx, searchParams, nil, deleteParams)
+	return e.DeleteWithContext(e.rest.ctx, searchParams, nil, deleteParams)
 }
 
 // DeleteById deletes a resource by its ID using the bound REST context and provided deleteParams.
 func (e *VastResource) DeleteById(id any, queryParams, deleteParams Params) (EmptyRecord, error) {
-    return e.DeleteByIdWithContext(e.rest.ctx, id, queryParams, deleteParams)
+	return e.DeleteByIdWithContext(e.rest.ctx, id, queryParams, deleteParams)
 }
 
 // DeleteNonId deletes a resource that does not use a numeric ID for identification.
 // The resource is identified using unique fields within the provided parameters (e.g., SID, UID).
 // This method delegates to DeleteNonIdWithContext using the default context.
 func (e *VastResource) DeleteNonId(queryParams, deleteParams Params) (EmptyRecord, error) {
-    return e.DeleteNonIdWithContext(e.rest.ctx, queryParams, deleteParams)
+	return e.DeleteNonIdWithContext(e.rest.ctx, queryParams, deleteParams)
 }
 
 // Ensure ensures a resource exists matching the searchParams. Creates it with body if not found.

--- a/session.go
+++ b/session.go
@@ -109,8 +109,8 @@ func NewVMSSession(config *VMSConfig) (*VMSSession, error) {
 }
 
 func request[T RecordUnion](
-    ctx context.Context,
-    r VastResourceAPIWithContext,
+	ctx context.Context,
+	r VastResourceAPIWithContext,
 	verb, path, apiVer string,
 	params, body Params,
 ) (T, error) {
@@ -246,18 +246,18 @@ func setupHeaders(s RESTSession, r *http.Request) error {
 // doRequest Create and process the new HTTP request using the context
 func doRequest(ctx context.Context, s *VMSSession, verb, url string, body Params, headers []http.Header) (Renderable, error) {
 	// callerExist if request is processed via "request" method
-    var (
-        config            = s.GetConfig()
-        resourceCaller    InterceptableVastResourceAPI
-        requestData       io.Reader
-        beforeRequestData io.Reader
-        err               error
-    )
-    originResource, resourceExist := ctx.Value(caller).(InterceptableVastResourceAPI)
+	var (
+		config            = s.GetConfig()
+		resourceCaller    InterceptableVastResourceAPI
+		requestData       io.Reader
+		beforeRequestData io.Reader
+		err               error
+	)
+	originResource, resourceExist := ctx.Value(caller).(InterceptableVastResourceAPI)
 	if !resourceExist {
-        resourceCaller = dummyResource
+		resourceCaller = dummyResource
 	} else {
-        resourceCaller = originResource
+		resourceCaller = originResource
 	}
 	// Check if called resource can be used with current version of VAST cluster.
 	if err = checkVastResourceVersionCompat(ctx, resourceCaller); err != nil {
@@ -331,10 +331,6 @@ func doRequestWithRetries(ctx context.Context, s *VMSSession, verb, url string, 
 		if err != nil && IsApiError(err) {
 			statusCode := err.(*ApiError).StatusCode
 			if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
-				if statusCode == http.StatusUnauthorized {
-					// Probably refresh token is expired. Need full re-authentication
-					s.auth.setInitialized(false)
-				}
 				if authErr := s.auth.authorize(); authErr != nil {
 					return nil, authErr
 				}


### PR DESCRIPTION
## Description

When API request is triggered, it calls doRequestWithRetry function. If Access token is expired, vast server throwback error with status code 403.
```
GET request to https://172.27.13.252:443/api/v5/quotas/1658/ returned status code 403 — response body: {
  "detail": "Given token not valid for any token type",
  "code": "token_not_valid",
  "messages": [
    {
      "token_class": "AccessToken",
      "token_type": "access",
      "message": "Token is invalid or expired"
    }
  ]
}
```

Since it is an API error and status code is 403, it will call authorize function and get new access token using refresh token. In the next try API call will be successful. But while calling authorize function if refresh token is also expired, it fails to get new access token and API call fails with following error.

```
POST request to https://172.27.13.252/api/token/refresh/ returned status code 401 — response body: {
  "detail": "Token is invalid or expired",
  "code": "token_not_valid"
}
```

Note that, there is a provision for full re-auth in doRequestWithRetry function, but it is never getting attempted because status code returned from API server is 403.

This PR is trying to address this issue. When refresh token is expired, authorize function itself will try to do re-authentication. Attempt of re-authentication from doRequestWithRetry function is removed.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added re-authentication attempt in authorize method when refresh token is expired.
- Removed an attempt of re-authentication from doRequestWithRetry function.

## Testing

- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested the examples affected by my changes

## Documentation

- [ ] My changes generate no new warnings in the documentation build

## Code Quality

- [ ] My code follows the Go style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new lint warnings
- [ ] I have run `make fmt` and `make lint` locally

## Breaking Changes

No breaking changes.

## Additional Notes


## Related Issues

