### PR TITLE
fix: validate integer→port conversions (gosec G115)

### DIFF
--- a/vastix/internal/client/client.go
+++ b/vastix/internal/client/client.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 
 	vastclient "github.com/vast-data/go-vast-client"
+
+	"vastix/internal/common"
 )
 
 // RestClientConfig holds configuration for a REST client
@@ -122,9 +124,13 @@ func NewRest(
 	sslVerify bool,
 	apiVersion string,
 ) (*vastclient.VMSRest, error) {
+	p, err := common.ToPort(port)
+	if err != nil {
+		return nil, err
+	}
 	vmsConfig := &vastclient.VMSConfig{
 		Host:       host,
-		Port:       uint64(port),
+		Port:       uint64(p),
 		Username:   username,
 		Password:   password,
 		ApiToken:   apiToken,

--- a/vastix/internal/common/port.go
+++ b/vastix/internal/common/port.go
@@ -1,5 +1,10 @@
 package common
 
+import (
+	"fmt"
+	"math"
+)
+
 // ToPort converts an integer to a uint16 TCP/UDP port number, returning an
 // error if it is outside the valid range [0, math.MaxUint16].
 //
@@ -7,8 +12,8 @@ package common
 // (e.g. uint16(65536) == 0), which gosec flags as G115. ToPort is the single
 // checked conversion used wherever the app turns an integer into a port.
 func ToPort(n int64) (uint16, error) {
-	// NOTE: range validation is added in the follow-up fix commit. This naive
-	// body intentionally reproduces the shipped bug so that TestToPort fails
-	// first (TDD red), then passes once the check is in place (green).
+	if n < 0 || n > math.MaxUint16 {
+		return 0, fmt.Errorf("port %d out of range [0, %d]", n, math.MaxUint16)
+	}
 	return uint16(n), nil
 }

--- a/vastix/internal/common/port.go
+++ b/vastix/internal/common/port.go
@@ -1,0 +1,14 @@
+package common
+
+// ToPort converts an integer to a uint16 TCP/UDP port number, returning an
+// error if it is outside the valid range [0, math.MaxUint16].
+//
+// A bare uint16(n) conversion silently truncates or wraps out-of-range values
+// (e.g. uint16(65536) == 0), which gosec flags as G115. ToPort is the single
+// checked conversion used wherever the app turns an integer into a port.
+func ToPort(n int64) (uint16, error) {
+	// NOTE: range validation is added in the follow-up fix commit. This naive
+	// body intentionally reproduces the shipped bug so that TestToPort fails
+	// first (TDD red), then passes once the check is in place (green).
+	return uint16(n), nil
+}

--- a/vastix/internal/common/port_test.go
+++ b/vastix/internal/common/port_test.go
@@ -1,0 +1,92 @@
+package common
+
+import (
+	"math"
+	"testing"
+)
+
+// TestToPort is table-driven and covers four categories: positive/valid,
+// negative, boundary (the off-by-one edges of the range), and corner/overflow
+// (values a bare uint16(n) conversion would silently truncate or wrap).
+func TestToPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      int64
+		want    uint16
+		wantErr bool
+	}{
+		// ── positive / valid ────────────────────────────────────────────
+		{"zero", 0, 0, false},
+		{"one", 1, 1, false},
+		{"http", 80, 80, false},
+		{"https", 443, 443, false},
+		{"alt-http", 8080, 8080, false},
+		{"wireguard-base", 51820, 51820, false},
+		{"max-valid", 65535, 65535, false},
+
+		// ── negative ────────────────────────────────────────────────────
+		{"negative-one", -1, 0, true},
+		{"negative-large", -51820, 0, true},
+		{"min-int64", math.MinInt64, 0, true},
+
+		// ── boundary (edges of [0, 65535]) ──────────────────────────────
+		{"lower-edge-valid", 0, 0, false},
+		{"lower-edge-invalid", -1, 0, true},
+		{"upper-edge-valid", 65535, 65535, false},
+		{"upper-edge-invalid", 65536, 0, true},
+
+		// ── corner / overflow (bare uint16(n) would truncate/wrap) ──────
+		{"wraps-to-zero", 65536, 0, true}, // uint16(65536) == 0
+		{"seventy-thousand", 70000, 0, true},
+		{"hundred-thousand", 100000, 0, true},
+		{"max-uint16-plus-one", math.MaxUint16 + 1, 0, true},
+		{"max-int64", math.MaxInt64, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToPort(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ToPort(%d): expected an error, got nil (result %d)", tt.in, got)
+				}
+				if got != 0 {
+					t.Errorf("ToPort(%d): on error want result 0, got %d", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ToPort(%d): unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("ToPort(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestToPort_NoAllocs enforces that the success path allocates nothing, so the
+// zero-alloc property is a guarantee rather than an observation.
+func TestToPort_NoAllocs(t *testing.T) {
+	if n := testing.AllocsPerRun(1000, func() {
+		_, _ = ToPort(443)
+	}); n != 0 {
+		t.Errorf("ToPort success path allocates %v times/op, want 0", n)
+	}
+}
+
+// BenchmarkToPort measures the hot (valid) path. Expect sub-nanosecond,
+// 0 B/op, 0 allocs/op — the function is trivially inlinable.
+func BenchmarkToPort(b *testing.B) {
+	for b.Loop() {
+		_, _ = ToPort(443)
+	}
+}
+
+// BenchmarkToPort_Invalid measures the error path, confirming the only cost
+// (the fmt.Errorf allocation) is confined to failures.
+func BenchmarkToPort_Invalid(b *testing.B) {
+	for b.Loop() {
+		_, _ = ToPort(70000)
+	}
+}

--- a/vastix/internal/vpn_connect/common/types.go
+++ b/vastix/internal/vpn_connect/common/types.go
@@ -4,6 +4,8 @@ package common
 import (
 	"fmt"
 	"net/netip"
+
+	shared "vastix/internal/common"
 )
 
 // VPNConfig represents a VPN configuration
@@ -103,8 +105,15 @@ func GenerateVPNNetwork(clientID int) (netip.Prefix, netip.Addr, netip.Addr, err
 // GetListenPort generates a unique listen port for a client
 // This allows multiple servers to run simultaneously
 func GetListenPort(clientID int) uint16 {
-	// Use ports 51820 + clientID (51821, 51822, ...)
-	return uint16(51820 + clientID)
+	// Use ports 51820 + clientID (51821, 51822, ...). clientID is bounded to
+	// 1-254 by GenerateVPNNetwork, so this never exceeds 52074; routing through
+	// ToPort makes the bound explicit and removes the unchecked uint16
+	// conversion that gosec flags as G115.
+	p, err := shared.ToPort(int64(51820) + int64(clientID))
+	if err != nil {
+		return 51820 // unreachable for valid clientIDs; fall back to the base port
+	}
+	return p
 }
 
 // Error types

--- a/vastix/internal/vpn_connect/server/cmd/main.go
+++ b/vastix/internal/vpn_connect/server/cmd/main.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 	"syscall"
 
+	shared "vastix/internal/common"
 	"vastix/internal/vpn_connect/common"
 	"vastix/internal/vpn_connect/server"
 )
 
 func main() {
 	// Command-line flags
-	port := flag.Uint("port", 51820, "VPN listen port")
+	port := flag.Int64("port", 51820, "VPN listen port")
 	serverIP := flag.String("server-ip", "", "Server VPN IP (e.g., 10.99.1.1)")
 	vpnNetwork := flag.String("vpn-network", "", "VPN network CIDR (e.g., 10.99.1.0/24)")
 	privateIPs := flag.String("private-ips", "", "Comma-separated list of private IPs to route (e.g., 172.21.101.10,172.21.101.11)")
@@ -52,7 +53,7 @@ func main() {
 		Level: logLevel,
 	}))
 
-	logger.Info("=== VPN Server Starting ===", slog.Uint64("port", uint64(*port)))
+	logger.Info("=== VPN Server Starting ===", slog.Int64("port", *port))
 
 	// Generate keys if not provided
 	var privKey, pubKey string
@@ -130,11 +131,20 @@ func main() {
 		logger.Info("Parsed private IPs", slog.Int("count", len(privateIPsList)))
 	}
 
+	// Validate the listen port through the single checked conversion. The flag
+	// is an int64 so the value reaches ToPort without a lossy cast; ToPort
+	// rejects anything outside [0, 65535] (gosec G115).
+	listenPort, err := shared.ToPort(*port)
+	if err != nil {
+		logger.Error("Invalid listen port", slog.Int64("port", *port), slog.Any("error", err))
+		os.Exit(1)
+	}
+
 	// Create server configuration
 	config := &common.ServerConfig{
 		PrivateKey: privKey,
 		PublicKey:  pubKey,
-		ListenPort: uint16(*port),
+		ListenPort: listenPort,
 		ServerIP:   srvIP,
 		VPNNetwork: vpnNet,
 		PrivateIPs: privateIPsList,
@@ -171,7 +181,7 @@ func main() {
 	logger.Info("Server configuration",
 		slog.String("public_key", pubKey),
 		slog.String("server_ip", srvIP.String()),
-		slog.Uint64("listen_port", uint64(*port)),
+		slog.Int64("listen_port", *port),
 		slog.String("vpn_network", vpnNet.String()),
 		slog.Int("private_ips_count", len(privateIPsList)),
 	)


### PR DESCRIPTION
## What

Fixes three `gosec` **G115** "integer overflow conversion" findings in the `vastix` module, where an integer was converted to a port with a bare cast that silently truncates or wraps out-of-range values.

Introduces one small, checked conversion helper — `common.ToPort(n int64) (uint16, error)` — and routes every integer→port conversion through it.

> **Note on scope:** two of the three findings (`GetListenPort` and the VPN server `main.go`) are in the legacy `internal/vpn_connect` code; the third (`NewRest`) is in the active `internal/client` package. All three are the same class of bug and are fixed the same way.

## Why

A bare `uint16(n)` / `uint64(port)` cast on an out-of-range value produces a wrong port with no error:

| input | `uint16(n)` (before) | after |
|------:|:--------------------:|:-----:|
| `-1` | `65535` | error |
| `65536` | `0` | error |
| `70000` | `4464` | error |

## How (TDD)

Two commits, deliberately ordered so the defect and its fix are each explicit in history:

1. **`test:`** adds `ToPort` with the *naive, unchecked* body that ships today, plus a table-driven test spec covering positive/valid, negative, boundary (range edges), and corner/overflow inputs, a zero-alloc assertion, and benchmarks. This commit is **red** — the tests fail, demonstrating the silent truncation.
2. **`fix:`** implements the `[0, 65535]` range check (tests go **green**) and adopts `ToPort` at all three sites:
   - `internal/client/client.go` `NewRest` — validate the `int64` port before `uint64(port)`.
   - `internal/vpn_connect/common/types.go` `GetListenPort` — route through `ToPort` in place; signature unchanged (`clientID` is bounded `1..254` by `GenerateVPNNetwork`, so the error path is unreachable and falls back defensively).
   - `internal/vpn_connect/server/cmd/main.go` — validate the listen port via `ToPort`; the `-port` flag becomes `int64` so the value reaches the helper without a lossy `uint→int64` cast (which itself tripped G115).

The helper uses the stdlib `math.MaxUint16` constant; the standard library has no integer→uint16 checked cast (`strconv.ParseUint`/`net.LookupPort` are string-based and would force string round-trips on these integer inputs).

## Verification

```
cd vastix
go test ./internal/common/            # PASS
go test -bench=. -benchmem ./internal/common/   # success path: 0 B/op, 0 allocs/op
go vet ./internal/common/ ./internal/client/ ./internal/vpn_connect/common/ ./internal/vpn_connect/server/cmd/
gosec ./...                           # 0 G115 findings (was 3)
```

Scope is intentionally tight: only the four packages containing the findings are touched, all of which compile and are covered. No behavior change for valid ports.

> Draft for review.
